### PR TITLE
chore: Bump to rust 2021 and format Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "rev_buf_reader"
 version = "0.2.0"
 authors = ["André Vicente Milack <andrevicente.m@gmail.com>"]
-edition = "2018"
+edition = "2021"
 description = "Crate that provides a buffered reader capable of reading chunks of bytes of a data stream in reverse order. Its implementation is an adapted copy of BufReader from the nightly std::io."
 repository = "https://github.com/andre-vm/rev_buf_reader"
 exclude = ["base/*"]
@@ -10,8 +10,8 @@ readme = "README.md"
 license = "Apache-2.0 OR MIT"
 
 [features]
-default=[]
-read_initializer=[]
+default = []
+read_initializer = []
 
 [dependencies]
-memchr="2.3.0"
+memchr = "2.3.0"


### PR DESCRIPTION
Bump to the new Rust 2021 version.

This also standartizes the Cargo.toml format